### PR TITLE
Use the local timezone for each jam

### DIFF
--- a/get_jams.py
+++ b/get_jams.py
@@ -1,5 +1,10 @@
 import csv
-from datetime import timedelta
+from datetime import timedelta,datetime
+from timezonefinder import TimezoneFinder
+import pytz
+import logging
+
+logger = logging.getLogger('get_jams')
 
 def download_csv(url):
     """Downloads and interprets a CSV"""
@@ -12,26 +17,62 @@ def download_csv(url):
         # Using Python3
         import urllib.request
         req = urllib.request.Request(url)
-        response = urllib.request.urlopen(req)
-    raw_data = response.read().decode('ascii')
-    return csv.reader(raw_data.split("\n")[1:])
+        try:
+            response = urllib.request.urlopen(req)
+            raw_data = response.read().decode('ascii')
+        except urllib.error.HTTPError as e:
+            logger.warning('Error fetching jam data: {}'.format(e))
+            try:
+                with open('dates.csv') as f:
+                    raw_data = f.read()
+            except FileNotFoundError:
+                raise Exception("Couldn't load jam data")
+    with open('dates.csv','w') as f:
+        f.write(raw_data)
+    return csv.DictReader(raw_data.split("\n"))
+
+class Jam(object):
+    def __init__(self, data):
+        self.city = data.get('city')
+        self.twitter = data.get('twitter')
+        lat,lng = (data.get('latitude'),data.get('longitude'))
+        try:
+            lat,lng = float(lat), float(lng)
+        except ValueError:
+            raise Exception("Invalid latitude/longitude: '{}' and '{}'".format(lat,lng))
+        if None not in (lat,lng):
+            tf = TimezoneFinder()
+            self.timezone = pytz.timezone(tf.timezone_at(lat=lat, lng=lng))
+        else:
+            self.timezone = None
+
+        self.next_date = self.timezone.localize(datetime.strptime(data.get('next_date'),'%Y-%m-%d').replace(hour=19))
+
+    def __str__(self):
+        return '{city} (@{twitter}) next meeting {date} ({timezone})'.format(
+                city=self.city,
+                twitter=self.twitter,
+                date=datetime.strftime(self.next_date,'%Y-%m-%d'),
+                timezone=self.timezone
+                )
+
+    def happening(self, margin_hours=24):
+        """ Is or was the Jam's start time within the given number of hours, relative to now? """
+        now = pytz.utc.localize(datetime.utcnow())
+        margin = timedelta(hours=margin_hours)
+        begin = now - margin
+        end = now + margin
+        return begin < self.next_date < end
 
 
-def get_jams(today):
-    """Gets the Twitter handles of MathsJams that happes on the day given and the day after the day given"""
-    data = download_csv("https://mathsjam.com/dates/")
-    day1 = today.strftime("%Y-%m-%d")
-    today -= timedelta(days=1)
-    day0 = today.strftime("%Y-%m-%d")
-
-    today += timedelta(days=2)
-    day2 = today.strftime("%Y-%m-%d")
-    today += timedelta(days=1)
-    day3 = today.strftime("%Y-%m-%d")
-    out = []
-    for row in data:
-        if len(row) == 3:
-            city,twitter,date = row
-            if date in [day0,day1,day2,day3] or day1 in ["2019-01-22","2019-01-23"]:
-                out.append(twitter)
-    return out
+def get_jams():
+    """Gets the Twitter handles of MathsJams that happen on the day given and the day after the day given"""
+    data = download_csv("https://mathsjam.com/datesa/")
+    jams = []
+    for d in data:
+        try:
+            jam = Jam(d)
+            jams.append(jam)
+        except Exception:
+            print("Invalid jam: {}".format(d))
+    return jams

--- a/get_jams.py
+++ b/get_jams.py
@@ -67,7 +67,7 @@ class Jam(object):
 
 def get_jams():
     """Gets the Twitter handles of MathsJams that happen on the day given and the day after the day given"""
-    data = download_csv("https://mathsjam.com/datesa/")
+    data = download_csv("https://mathsjam.com/dates/")
     jams = []
     for d in data:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-twitter
+twitter==1.18.0
+pytz==2018.9
+timezonefinder==3.4.2

--- a/tweet.py
+++ b/tweet.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from twitter import Twitter
+from twitter import Twitter,OAuth
 from get_jams import get_jams
 from datetime import datetime
 import config
@@ -13,7 +13,7 @@ test = "test" in sys.argv
 twitter = Twitter(auth=OAuth(config.access_key, config.access_secret,
                              config.consumer_key, config.consumer_secret))
 
-all_jams = get_jams(datetime.now())
+all_jams = get_jams()
 happening_jams = [jam for jam in all_jams if jam.happening()]
 
 def today(tweet):


### PR DESCRIPTION
fixes #1

get_jams uses the timezonefinder to work out which timezone each Jam is
in, based on its lat/lon coordinates.

A Jam is 'happening' within 24 hours of 7PM local time.

This commit also adds some error handling, and saves a local copy of the
dates.csv file in case mathsjam.com goes down.

I haven't tested it fully, because I don't have twitter API credentials.
get_jamspy works, at least.